### PR TITLE
add extra columns for extra billing tags

### DIFF
--- a/lib/redshift.js
+++ b/lib/redshift.js
@@ -1,82 +1,82 @@
-'use strict'
+"use strict";
 
-var AWS = require('aws-sdk')
-var log = require('loglevel')
-var moment = require('moment')
-var pg = require('pg')
-var types = require('pg').types
+var AWS = require("aws-sdk");
+var log = require("loglevel");
+var moment = require("moment");
+var pg = require("pg");
+var types = require("pg").types;
 
 // Redshift doesn't have TIMESTAMP WITH TIME ZONE
 // All dates will therefore come back here as localtime
 // This forces dates to come back as UTC.
 // See https://github.com/brianc/node-pg-types/blob/master/lib/textParsers.js
 // Also http://stackoverflow.com/questions/20712291/use-node-postgres-to-get-postgres-timestamp-without-timezone-in-utc
-types.setTypeParser(1082, function (stringVal) {
-  return new Date(stringVal)
-})
+types.setTypeParser(1082, function(stringVal) {
+  return new Date(stringVal);
+});
 
-module.exports = Redshift
+module.exports = Redshift;
 
-function Redshift (connString) {
-  this.connString = connString
+function Redshift(connString) {
+  this.connString = connString;
   // We use role-based authentication, so these are pulled from the environment
-  this.s3 = new AWS.S3()
-  this.lineItemsTableName = process.env.LINE_ITEMS_TABLE_NAME || 'line_items'
-  this.schema = process.env.SCHEMA || 'heroku'
+  this.s3 = new AWS.S3();
+  this.lineItemsTableName = process.env.LINE_ITEMS_TABLE_NAME || "line_items";
+  this.schema = process.env.SCHEMA || "heroku";
 }
 
 // Execute a query, using the query pool
 // Return a promise which resolves with the output of the query.
-Redshift.prototype.executeQuery = function (query, transform) {
-  var self = this
-  log.debug('Executing query:')
-  log.debug(query)
-  return new Promise(function (resolve, reject) {
-    pg.connect(self.connString, function (err, client, done) {
+Redshift.prototype.executeQuery = function(query, transform) {
+  var self = this;
+  log.debug("Executing query:");
+  log.debug(query);
+  return new Promise(function(resolve, reject) {
+    pg.connect(self.connString, function(err, client, done) {
       if (err) {
         reject(err);
         return;
       }
-      client.query(query, function (err, result) {
+      client.query(query, function(err, result) {
         if (err) {
           reject(err);
           return;
         }
         if (transform !== undefined) {
-          result = transform(result)
+          result = transform(result);
         }
-        done(client)
-        return resolve(result)
-      })
-    })
-  })
-}
+        done(client);
+        return resolve(result);
+      });
+    });
+  });
+};
 
 // Execute a query where the desired output is a single scalar value.
-Redshift.prototype.getScalar = function (query, keyName) {
-  let transform = function (result) {
-    let rowzero = result.rows[0]
+Redshift.prototype.getScalar = function(query, keyName) {
+  let transform = function(result) {
+    let rowzero = result.rows[0];
     if (keyName !== undefined) {
-      return rowzero[keyName]
+      return rowzero[keyName];
     } else {
       // return the value of the first key
-      return rowzero[Object.keys(rowzero)[0]]
+      return rowzero[Object.keys(rowzero)[0]];
     }
-  }
-  return this.executeQuery(query, transform)
-}
+  };
+  return this.executeQuery(query, transform);
+};
 
 // Execute a query where the desired output is a count of affected rows
 // (for example, DELETE FROM queries).
-Redshift.prototype.getRowCount = function (query) {
-  let transform = function (result) {
-    return result.rowCount
-  }
-  return this.executeQuery(query, transform)
-}
+Redshift.prototype.getRowCount = function(query) {
+  let transform = function(result) {
+    return result.rowCount;
+  };
+  return this.executeQuery(query, transform);
+};
 
 // Check that a table exists. Won't match on views or other table-like things.
-Redshift.prototype.checkTableExists = function (tableName, schema) {
+Redshift.prototype.checkTableExists = function(tableName, schema) {
   let query = `
     SELECT EXISTS (
       SELECT 1
@@ -85,24 +85,24 @@ Redshift.prototype.checkTableExists = function (tableName, schema) {
       WHERE  n.nspname = '${schema}'
       AND    c.relname = '${tableName}'
       AND    c.relkind = 'r'    -- only tables
-    ) as exists;`
+    ) as exists;`;
 
-  let transform = function (result) {
-    return result.rows[0].exists === 't'
-  }
-  return this.executeQuery(query, transform)
-}
+  let transform = function(result) {
+    return result.rows[0].exists === "t";
+  };
+  return this.executeQuery(query, transform);
+};
 
 // Determine whether a specific finalized month has already been imported.
-Redshift.prototype.hasMonth = function (month) {
+Redshift.prototype.hasMonth = function(month) {
   let query = `
     SELECT COUNT(*)
     FROM ${this.schema}.${this.lineItemsTableName}
-    WHERE statement_month = '${month.format('YYYY-MM-01')}'
+    WHERE statement_month = '${month.format("YYYY-MM-01")}'
       AND invoice_id != 'Estimated' AND invoice_id != ''
   ;`;
-  return this.getScalar(query, 'count').then(function (count) {
-    return (count > 0);
+  return this.getScalar(query, "count").then(function(count) {
+    return count > 0;
   });
 };
 
@@ -110,65 +110,84 @@ Redshift.prototype.hasMonth = function (month) {
 // First, create a staging table and COPY FROM into that.
 // Then, add the statement_month column, and copy it all to line_items.
 // Then drop the staging table.
-Redshift.prototype.importFullMonth = function (s3uri, month, pruneThresholdMonths) {
-  const monthString = month.format('YYYY_MM');
-  const monthDateString = month.format('YYYY-MM-01');
+Redshift.prototype.importFullMonth = function(
+  s3uri,
+  month,
+  pruneThresholdMonths
+) {
+  const monthString = month.format("YYYY_MM");
+  const monthDateString = month.format("YYYY-MM-01");
   const stagingTableName = `staging_${monthString}`;
-  let pruneQueryFragment = '';
-  if (typeof pruneThresholdMonths === 'number') {
+  let pruneQueryFragment = "";
+  if (typeof pruneThresholdMonths === "number") {
     // Delete statement months that are older than X months ago
     let pruneThresholdString = moment(month)
-      .subtract(pruneThresholdMonths, 'months')
-      .format('YYYY-MM-01');
-    pruneQueryFragment = `DELETE FROM ${this.schema}.line_items WHERE statement_month <= '${pruneThresholdString}'::DATE;`;
+      .subtract(pruneThresholdMonths, "months")
+      .format("YYYY-MM-01");
+    pruneQueryFragment = `DELETE FROM ${this
+      .schema}.line_items WHERE statement_month <= '${pruneThresholdString}'::DATE;`;
   }
 
   // If you add more rows here, you have to add them to the CREATE TABLE
   // statement, and ensure they're in the same order.
   let selectStatement = [
-    'invoice_id',
-    'payer_account_id',
-    'linked_account_id',
-    'record_type',
-    'record_id',
-    'product_name',
-    'rate_id',
-    'subscription_id',
-    'pricing_plan_id',
-    'usage_type',
-    'operation',
-    'availability_zone',
-    'reserved_instance',
-    'item_description',
-    'usage_start_date',
-    'usage_end_date',
-    'usage_quantity',
-    'blended_rate',
-    'blended_cost',
-    'unblended_rate',
-    'unblended_cost',
-    'resource_id',
+    "invoice_id",
+    "payer_account_id",
+    "linked_account_id",
+    "record_type",
+    "record_id",
+    "product_name",
+    "rate_id",
+    "subscription_id",
+    "pricing_plan_id",
+    "usage_type",
+    "operation",
+    "availability_zone",
+    "reserved_instance",
+    "item_description",
+    "usage_start_date",
+    "usage_end_date",
+    "usage_quantity",
+    "blended_rate",
+    "blended_cost",
+    "unblended_rate",
+    "unblended_cost",
+    "resource_id"
   ];
 
-  let awsCreatedByFragment = '';
+  let awsCreatedByFragment = "";
   // roughly when we added it - all we care about is that it's present in the
   // January 2017 CSV, not in the older ones.
   let awsCreatedByAdded = moment([2016, 11, 15]);
-  if (awsCreatedByAdded.diff(month, 'days') < 0) { // awsCreatedBy is older
+  if (awsCreatedByAdded.diff(month, "days") < 0) {
+    // awsCreatedBy is older
     awsCreatedByFragment = `aws_created_by TEXT,`;
-    selectStatement.push('aws_created_by');
+    selectStatement.push("aws_created_by");
   }
 
-  let productAreaQueryFragment = '';
+  let clusterTagsQueryFragment = "";
+  // we added the cluster tags in the July 2017 CSV.
+  let clusterTagsQueryAdded = moment([2017, 6, 25]);
+  if (clusterTagsQueryAdded.diff(month, "days") < 0) {
+    clusterTagsQueryFragment = `cluster TEXT, host_class TEXT, service TEXT,`;
+    selectStatement = selectStatement.concat([
+      "cluster",
+      "host_class",
+      "service"
+    ]);
+  }
+
+  let productAreaQueryFragment = "";
   // roughly when we added it - all we care about is that it's present in the
   // January 2017 CSV, not in the older ones.
   let productAreaAdded = moment([2016, 11, 15]);
-  if (productAreaAdded.diff(month, 'days') < 0) { // productAreaAdded is older
+  if (productAreaAdded.diff(month, "days") < 0) {
+    // productAreaAdded is older
     productAreaQueryFragment = `product_area TEXT,`;
-    selectStatement.push('product_area');
+    selectStatement.push("product_area");
   }
   // This gets added via ALTER TABLE
-  selectStatement.push('statement_month');
+  selectStatement.push("statement_month");
 
   var self = this;
   return this.credentialString().then(function(creds) {
@@ -203,6 +222,7 @@ Redshift.prototype.importFullMonth = function (s3uri, month, pruneThresholdMonth
           unblended_cost NUMERIC(18,11),
           resource_id TEXT,
           ${awsCreatedByFragment}
+          ${clusterTagsQueryFragment}
           ${productAreaQueryFragment}
           PRIMARY KEY(record_id)
         ) DISTSTYLE EVEN;
@@ -214,61 +234,67 @@ Redshift.prototype.importFullMonth = function (s3uri, month, pruneThresholdMonth
         ALTER TABLE ${self.schema}.${stagingTableName} ADD COLUMN statement_month DATE DEFAULT '${monthDateString}';
         DELETE FROM ${self.schema}.${self.lineItemsTableName} WHERE statement_month = '${monthDateString}';
         INSERT INTO ${self.schema}.${self.lineItemsTableName} (
-          ${selectStatement.join(',\n')}
-        ) SELECT ${selectStatement.join(',\n')}
+          ${selectStatement.join(",\n")}
+        ) SELECT ${selectStatement.join(",\n")}
          FROM ${self.schema}.${stagingTableName};
         DROP TABLE ${self.schema}.${stagingTableName};
         ${pruneQueryFragment}
-      COMMIT;`
+      COMMIT;`;
 
-    return self.executeQuery(query)
+    return self.executeQuery(query);
   });
-}
+};
 
 // Import the month-to-date DBR into the month_to_date table, clobbering
 // whatever was already there.
-Redshift.prototype.importMonthToDate = function (s3uri) {
-  let self = this
-  let truncateQuery = `TRUNCATE ${self.schema}.month_to_date;`
+Redshift.prototype.importMonthToDate = function(s3uri) {
+  let self = this;
+  let truncateQuery = `TRUNCATE ${self.schema}.month_to_date;`;
   var credentialString = null;
-  return self.credentialString().then(function(creds) {
-    credentialString = creds;
-    return self.executeQuery(truncateQuery);
-  }).then(function () {
-    log.debug('Month to date table truncated. Importing...')
-    let query = `
+  return self
+    .credentialString()
+    .then(function(creds) {
+      credentialString = creds;
+      return self.executeQuery(truncateQuery);
+    })
+    .then(function() {
+      log.debug("Month to date table truncated. Importing...");
+      let query = `
       COPY ${self.schema}.month_to_date
         FROM '${s3uri}'
         CREDENTIALS '${credentialString}'
         GZIP CSV IGNOREHEADER 1;
-    `
-    return self.executeQuery(query)
-  })
+    `;
+      return self.executeQuery(query);
+    });
 };
 
 Redshift.prototype.credentialString = function() {
   var build = function(creds) {
     // http://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html#copy-iam-role
     var credentialParts = [];
-    if (typeof creds.accessKeyId === 'string') {
-      credentialParts.push('aws_access_key_id=' + creds.accessKeyId);
+    if (typeof creds.accessKeyId === "string") {
+      credentialParts.push("aws_access_key_id=" + creds.accessKeyId);
     }
-    if (typeof creds.secretAccessKey === 'string') {
-      credentialParts.push('aws_secret_access_key=' + creds.secretAccessKey);
+    if (typeof creds.secretAccessKey === "string") {
+      credentialParts.push("aws_secret_access_key=" + creds.secretAccessKey);
     }
-    if (typeof creds.sessionToken === 'string') {
-      credentialParts.push('token=' + creds.sessionToken);
+    if (typeof creds.sessionToken === "string") {
+      credentialParts.push("token=" + creds.sessionToken);
     }
-    return credentialParts.join(';');
+    return credentialParts.join(";");
   };
   var self = this;
   return new Promise(function(resolve, reject) {
-    if (typeof self.s3.config.credentials !== 'undefined' && self.s3.config.credentials !== null) {
+    if (
+      typeof self.s3.config.credentials !== "undefined" &&
+      self.s3.config.credentials !== null
+    ) {
       resolve(build(self.s3.config.credentials));
       return;
     }
     self.s3.config.credentialProvider.resolve(function(err, credentials) {
-      if (typeof err !== 'undefined' && err !== null) {
+      if (typeof err !== "undefined" && err !== null) {
         reject(err);
         return;
       }
@@ -279,7 +305,7 @@ Redshift.prototype.credentialString = function() {
 };
 
 // Vacuum the database.
-Redshift.prototype.vacuum = function (tableName) {
-  let query = `VACUUM ${(this.schema) + '.' + tableName || ''};`
-  return this.executeQuery(query)
-}
+Redshift.prototype.vacuum = function(tableName) {
+  let query = `VACUUM ${this.schema + "." + tableName || ""};`;
+  return this.executeQuery(query);
+};


### PR DESCRIPTION
In this month's CSV we saw the following new format for columns:

"InvoiceID","PayerAccountId","LinkedAccountId","RecordType","RecordId","ProductName","RateId","SubscriptionId","PricingPlanId","UsageType","Operation","AvailabilityZone","ReservedInstance","ItemDescription","UsageStartDate","UsageEndDate","UsageQuantity","BlendedRate","BlendedCost","UnBlendedRate","UnBlendedCost","ResourceId","aws:createdBy","user:Cluster","user:HostClass","user:Service","user:product_area"

Vs the month before, where we saw no tags:

"InvoiceID","PayerAccountId","LinkedAccountId","RecordType","RecordId","ProductName","RateId","SubscriptionId","PricingPlanId","UsageType","Operation","AvailabilityZone","ReservedInstance","ItemDescription","UsageStartDate","UsageEndDate","UsageQuantity","BlendedRate","BlendedCost","UnBlendedRate","UnBlendedCost","ResourceId","aws:createdBy","user:product_area"

Eventually we should fix this worker to pull dynamically from the
schema in the CSV. Until that happens, this commit will add the
relevant new user tags.