### PR TITLE
Adding statsd metrics for error/success/ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 *.csv
 *.zip
+
+*~
+*#

--- a/import_month_to_date.js
+++ b/import_month_to_date.js
@@ -14,6 +14,7 @@ var BaseParser = require('./lib/baseparser.js')
 var DBR = require('./lib/dbr.js')
 var Redshift = require('./lib/redshift.js')
 var cliUtils = require('./lib/cliutils.js')
+var stats = require('./lib/stats')
 
 rollbar.init(process.env.ROLLBAR_TOKEN, {environment: process.env.ROLLBAR_ENVIRONMENT})
 rollbar.handleUncaughtExceptions(process.env.ROLLBAR_TOKEN,
@@ -70,8 +71,12 @@ dbr.getMonthToDateDBR()
   .then(vacuum)
   .then(function () {
     cliUtils.runCompleteHandler(startTime, 0)
+    stats.incr('import_month_to_date.success')
   })
-  .catch(cliUtils.rejectHandler)
+  .catch(function (err) {
+    cliUtils.rejectHandler(err)
+    stats.incr('import_month_to_date.error')
+  })
 
 // Determine whether to stage the latest month-to-date DBR or reuse existing
 function stageDBRCheck (monthToDateDBR) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,2 @@
+exports.STATSD_HOST = process.env.STATSD_HOST || '172.17.42.1'
+exports.STATSD_PORT = process.env.STATSD_PORT || '8125'

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,0 +1,10 @@
+const { STATSD_HOST, STATSD_PORT } = require('./config')
+const Stats = require('dog-statsy')
+
+const stats = new Stats({
+    host: STATSD_HOST,
+    port: STATSD_PORT,
+    prefix: 'billing-to-redshift'
+})
+
+module.exports = stats

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "argparse": "^1.0.1",
     "aws-sdk": "^2.1.17",
     "debounce": "^1.0.0",
+    "dog-statsy": "^1.1.1",
     "lodash": "^3.6.0",
     "loglevel": "^1.2.0",
     "moment": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,9 +85,20 @@ debounce@^1.0.0:
   dependencies:
     date-now "1.0.1"
 
+debug@~0.8.0:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-0.8.1.tgz#20ff4d26f5e422cb68a1bacbbb61039ad8c1c130"
+
 decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+dog-statsy@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/dog-statsy/-/dog-statsy-1.1.1.tgz#de6651907651e8e3f056155e981d85152d54be98"
+  dependencies:
+    debug "~0.8.0"
+    forward-events "0.0.1"
 
 error-ex@^1.2.0:
   version "1.3.1"
@@ -101,6 +112,10 @@ find-up@^1.0.0:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
+
+forward-events@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/forward-events/-/forward-events-0.0.1.tgz#76744a1765d52c93aa9f155078474e2e501b7902"
 
 generic-pool@2.4.2:
   version "2.4.2"


### PR DESCRIPTION
We currently do not have a way to determine whether the awsbilling ECS task fails or succeeds. This adds metrics that will be made available in datadog (via statsd)